### PR TITLE
Fix back button navigation across all screens

### DIFF
--- a/screens/ContactDetailsScreen.tsx
+++ b/screens/ContactDetailsScreen.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView, Linking, TextInput, Modal } from "react-native";
-import { useRoute, useNavigation } from "@react-navigation/native";
+import React, { useState, useCallback } from "react";
+import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView, Linking, TextInput, Modal, BackHandler } from "react-native";
+import { useRoute, useNavigation, useFocusEffect } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RootStackParamList } from "../App";
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -15,6 +15,19 @@ const ContactDetails: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [photoViewerVisible, setPhotoViewerVisible] = useState(false);
   const [selectedPhoto, setSelectedPhoto] = useState<{ url: string; name: string } | null>(null);
+
+  // Back button logic to navigate back to FacultyDirectory
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        navigation.navigate('FacultyDirectory');
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
+    }, [navigation])
+  );
 
   const handleCall = (phone: string) => {
     Linking.openURL(`tel:${phone}`);

--- a/screens/ExamDuty.tsx
+++ b/screens/ExamDuty.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -9,8 +9,9 @@ import {
   Alert,
   StatusBar,
   Animated,
+  BackHandler,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../App';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -80,6 +81,19 @@ const ExamDuty: React.FC = () => {
       })
     ]).start();
   }, []);
+
+  // Back button logic to navigate back to MainScreen
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        navigation.navigate('MainScreen');
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
+    }, [navigation])
+  );
 
   const filteredDuties = examDuties.filter(duty => 
     selectedFilter === 'all' ? true : duty.status === selectedFilter

--- a/screens/FacultyDirectory.tsx
+++ b/screens/FacultyDirectory.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { View, Text, TextInput, FlatList, StyleSheet, TouchableOpacity, Image, RefreshControl, Modal, ScrollView, Animated } from "react-native";
+import React, { useState, useEffect, useCallback } from "react";
+import { View, Text, TextInput, FlatList, StyleSheet, TouchableOpacity, Image, RefreshControl, Modal, ScrollView, Animated, BackHandler } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import Icon from 'react-native-vector-icons/FontAwesome'; // Import FontAwesome icons
 import { StackNavigationProp } from '@react-navigation/stack'; // Import StackNavigationProp
@@ -85,6 +85,19 @@ const FacultyDirectory: React.FC = () => {
   useEffect(() => {
     loadData();
   }, []);
+
+  // Back button logic to navigate back to MainScreen
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        navigation.navigate('MainScreen');
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
+    }, [navigation])
+  );
 
 
 

--- a/screens/FacultyNotice.tsx
+++ b/screens/FacultyNotice.tsx
@@ -81,7 +81,7 @@ const FacultyNotice = () => {
   // Handle hardware back button
   useEffect(() => {
     const backAction = () => {
-      navigation.goBack();
+      navigation.navigate('MainScreen');
       return true;
     };
 

--- a/screens/HallBooking.tsx
+++ b/screens/HallBooking.tsx
@@ -13,6 +13,8 @@ import {
 } from 'react-native';
 import { useTheme } from '../components/theme-provider';
 import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../App';
 import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -50,14 +52,14 @@ interface BookingRequest {
 
 const HallBooking: React.FC = () => {
   const { theme } = useTheme();
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const [isAdmin, setIsAdmin] = useState(false); // Toggle for admin view
   const [activeTab, setActiveTab] = useState<'book' | 'requests' | 'admin'>('book');
 
   // Handle hardware back button
   useEffect(() => {
     const backAction = () => {
-      navigation.goBack();
+      navigation.navigate('MainScreen');
       return true;
     };
 

--- a/screens/NotificationScreen.tsx
+++ b/screens/NotificationScreen.tsx
@@ -1,14 +1,12 @@
-import React, { useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity, StatusBar, ScrollView, Animated, Image } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import React, { useState, useCallback } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, StatusBar, ScrollView, Animated, Image, BackHandler } from "react-native";
+import { useNavigation, useFocusEffect } from "@react-navigation/native";
 import { StackNavigationProp } from '@react-navigation/stack';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { useTheme } from "../components/theme-provider";
 import { LinearGradient } from 'expo-linear-gradient';
 
-type RootStackParamList = {
-  HomePage: undefined;
-};
+import type { RootStackParamList } from "../App";
 
 interface Notification {
   id: string;
@@ -22,6 +20,19 @@ interface Notification {
 const NotificationScreen: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { theme } = useTheme();
+
+  // Back button logic to navigate back to MainScreen
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        navigation.navigate('MainScreen');
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
+    }, [navigation])
+  );
   const [notifications, setNotifications] = useState<Notification[]>([
     // Sample notifications to demonstrate the design
     {

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -46,7 +46,7 @@ const ProfileScreen: React.FC = () => {
   // Handle hardware back button
   useEffect(() => {
     const backAction = () => {
-      navigation.goBack();
+      navigation.navigate('MainScreen');
       return true;
     };
 

--- a/screens/SettingsPage.tsx
+++ b/screens/SettingsPage.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { View, Text, TouchableOpacity, StyleSheet, Alert, Image } from "react-native";
+import React, { useCallback } from "react";
+import { View, Text, TouchableOpacity, StyleSheet, Alert, Image, BackHandler } from "react-native";
 import supabase from "../supabase"; // Import Supabase client
-import { useNavigation, NavigationProp } from "@react-navigation/native";
+import { useNavigation, NavigationProp, useFocusEffect } from "@react-navigation/native";
 import type { RootStackParamList } from "../App"; // Fixed import syntax
 import { useTheme } from "../components/theme-provider";
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -9,6 +9,19 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 const SettingsPage: React.FC = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { theme, themeMode, setThemeMode } = useTheme();
+
+  // Back button logic to navigate back to MainScreen
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        navigation.navigate('MainScreen');
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
+    }, [navigation])
+  );
 
   const handleLogout = async () => {
     const { error } = await supabase.auth.signOut();


### PR DESCRIPTION
## Changes Made
- Fixed back button navigation for all screens
- Faculty Directory → Back → MainScreen (Home)
- Faculty Details → Back → Faculty Directory  
- Settings → Back → MainScreen (Home)
- Exam Duty → Back → MainScreen (Home)
- Hall Booking → Back → MainScreen (Home)
- Faculty Notice → Back → MainScreen (Home)
- Notifications → Back → MainScreen (Home)
- Profile → Back → MainScreen (Home)

## Behavior
- Only MainScreen (Home) shows exit confirmation on back press
- All other screens navigate back to appropriate previous screen
- Consistent navigation hierarchy across the app

## Screens Updated
- FacultyDirectory.tsx
- SettingsPage.tsx
- ExamDuty.tsx
- HallBooking.tsx
- FacultyNotice.tsx
- ContactDetailsScreen.tsx
- NotificationScreen.tsx
- ProfileScreen.tsx